### PR TITLE
Fix version number

### DIFF
--- a/oauth_provider/__init__.py
+++ b/oauth_provider/__init__.py
@@ -1,2 +1,2 @@
 VERSION = '2.2.9.edx-1'
-__version__ = ".".join([str(x) for x in VERSION])
+__version__ = VERSION


### PR DESCRIPTION
This fixes `__version__` to match the string version number in `VERSION`. I saw this issue when I was looking over the edX dependencies in Travis:

    Requested django-oauth-plus==2.2.9.edx-1 from git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1 (from -r requirements/edx/github.txt (line 70)), but installing version 2...2...9...e.d.x.-.1

