### PR TITLE
Changing prefix from b to u in migration files to fix type mismatch

### DIFF
--- a/oauth_provider/__init__.py
+++ b/oauth_provider/__init__.py
@@ -1,2 +1,2 @@
-VERSION = '2.2.9.edx-2'
+VERSION = '2.2.9.edx-3'
 __version__ = VERSION

--- a/oauth_provider/migrations/0001_initial.py
+++ b/oauth_provider/migrations/0001_initial.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
                 ('key', models.CharField(max_length=256)),
                 ('secret', models.CharField(max_length=16, blank=True)),
                 ('status', models.SmallIntegerField(default=1, choices=[(1, 'Pending'), (2, 'Accepted'), (3, 'Canceled'), (4, 'Rejected')])),
-                ('xauth_allowed', models.BooleanField(default=False, verbose_name=b'Allow xAuth')),
+                ('xauth_allowed', models.BooleanField(default=False, verbose_name=u'Allow xAuth')),
                 ('user', models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True)),
             ],
             options={

--- a/oauth_provider/models.py
+++ b/oauth_provider/models.py
@@ -62,7 +62,7 @@ class Consumer(models.Model):
 
     status = models.SmallIntegerField(choices=CONSUMER_STATES, default=PENDING)
     user = models.ForeignKey(AUTH_USER_MODEL, null=True, blank=True)
-    xauth_allowed = models.BooleanField("Allow xAuth", default=False)
+    xauth_allowed = models.BooleanField(u"Allow xAuth", default=False)
 
     def __unicode__(self):
         return u"Consumer %s with key %s" % (self.name, self.key)


### PR DESCRIPTION
	-The 'b' prefix before strings in migration files causes issues in python3
	- this commit replaces 'b' prefix with 'u' in migration files and adds 'u' prefix in relevant places in model.py
	- this should not cause any issues in python 2